### PR TITLE
feat: add customer support agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ If you have any questions or if you found any problems with this repository, ple
 | DeBank Portfolio Analyzer   | Multi-chain portfolio analysis using DeBank data (balances, tokens, protocols, NFTs); debank-mcp adoption | MCP integration, debank-mcp, McpToolset, DeBank API, Single-agent tool orchestration                               | `portfolio`, `debank`, `mcp`, `defi`    | Conversational   | Intermediate | Single Agent | Web3/DeFi       |
 | DAO Proposal Analyzer       | Multi-chain DAO proposal analysis and voting recommendations (Ethereum + Fraxtal L2)                      | Sequential agents, Multi-chain viem integration, Governance analysis, Multi-agent orchestration                    | `dao`, `governance`, `web3`, `voting`   | Workflow         | Advanced     | Multi-agent  | Web3/Governance |
 | Social Media Drafting Agent | Turns any blog URL into LinkedIn, X, and Threads drafts (single post or 2–10 post threads)                | Single LlmAgent, WebFetchTool, cache + retry plugins, Zod output schema, Next.js server actions                    | `content`, `social`, `nextjs`           | Workflow         | Intermediate | Single Agent | General         |
+| Customer Support Agent      | Web chat UI and terminal CLI for Acme Corp support: policy Q&A, live order/account lookup, and escalation | FileOperationsTool, HttpRequestTool, createTool, Session state, React + Vite frontend, Node HTTP server            | `support`, `tools`, `session-state`     | Conversational   | Beginner     | Single Agent | General         |
 
 ## 🤝 Contributing
 

--- a/apps/customer-support-agent/.env.example
+++ b/apps/customer-support-agent/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to .env and fill in your values
+# cp .env.example .env
+
+# Model to use — defaults to gemini-2.5-flash if not set
+# Other options: gpt-4o, claude-3-5-sonnet-20241022, gemini-2.5-pro
+LLM_MODEL=gemini-2.5-flash
+
+# API keys — only the one matching your chosen model is required
+
+# Google Gemini (default)
+GOOGLE_API_KEY=your_google_api_key_here
+
+# OpenAI
+# OPENAI_API_KEY=your_openai_api_key_here
+
+# Anthropic Claude
+# ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/apps/customer-support-agent/.gitignore
+++ b/apps/customer-support-agent/.gitignore
@@ -1,0 +1,34 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+dist-ssr/
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# Editor
+.vscode/
+.idea/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+
+# OS
+.DS_Store
+Thumbs.db
+
+# TypeScript
+*.tsbuildinfo
+
+# Vite
+.vite/

--- a/apps/customer-support-agent/LICENSE
+++ b/apps/customer-support-agent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 IQ AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/customer-support-agent/README.md
+++ b/apps/customer-support-agent/README.md
@@ -1,0 +1,233 @@
+<div align="center">
+  <img src="https://files.catbox.moe/vumztw.png" alt="ADK-TS Logo" width="80" />
+  <br/>
+  <h1>Customer Support Agent</h1>
+  <b>A single-agent customer support chatbot with built-in tools, custom tool, and session state, built on the <code>ADK-TS</code> framework.</b>
+  <br/>
+  <i>Single-Agent • Built-in Tools • Custom Tool • Session State • React • Vite • TypeScript</i>
+</div>
+
+---
+
+An AI-powered customer support agent for Acme Corp built with a single **LlmAgent** in ADK-TS. It answers policy questions from local markdown files, fetches live order and account data via HTTP, and escalates unresolvable issues to a human agent via a custom tool — all with session state tracking the escalation status. Runs as both a React web chat UI and an interactive terminal CLI.
+
+## Features
+
+- **Policy Q&A**: Reads shipping, return, payment, and membership policies from local markdown files using the built-in `FileOperationsTool`
+- **Live order lookup**: Fetches real-time cart/order data by order number using the built-in `HttpRequestTool`
+- **Account lookup**: Retrieves user account details by user ID via the same `HttpRequestTool`
+- **Human escalation**: Custom `escalate_to_human` tool creates a timestamped ticket ID, sets session state, and flags the conversation for follow-up
+- **Session state**: Tracks escalation status across the full conversation using ADK-TS state — the agent knows not to re-escalate
+- **Two run modes**: Web chat UI (React + Vite) or interactive terminal CLI (readline) — same agent, two interfaces
+- **Multi-model support**: Swap between Gemini, OpenAI, or Anthropic Claude with a single env var change
+
+## Architecture and Workflow
+
+This project demonstrates the **single LlmAgent with built-in tools, a custom tool, and session state** pattern in ADK-TS — one agent equipped with two built-in tools, one hand-rolled tool, and shared state that persists across turns.
+
+### How It Works
+
+| Piece                      | Role                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| **LlmAgent**               | Handles all user messages and decides which tool to call                              |
+| **FileOperationsTool**     | Lists and reads markdown files from `src/server/knowledge-base/` to answer policy Q&A |
+| **HttpRequestTool**        | Makes outbound GET requests to fetch live order and account data                      |
+| **escalate_to_human tool** | Custom tool: creates a ticket ID, sets `escalated` state, logs a support ticket       |
+| **Node HTTP Server**       | Exposes a `/chat` POST endpoint for the React UI                                      |
+| **Vite Dev Server**        | Serves the React chat UI and proxies `/chat` to the Node server                       |
+
+### Data Flow
+
+```mermaid
+flowchart TD
+    U["👤 User"] --> UI["Chat UI\n(React + Vite)"]
+    U --> CLI["Terminal CLI\n(readline)"]
+    UI -->|POST /chat| S["Node HTTP Server\nsrc/server/server.ts"]
+    CLI --> R
+    S --> R["Agent Runner\n(ADK-TS)"]
+    R --> LLM["LLM\n(Gemini / OpenAI / Claude)"]
+    LLM --> F["FileOperationsTool\nreads knowledge-base/*.md"]
+    LLM --> H["HttpRequestTool\nGET dummyjson.com/carts or /users"]
+    LLM --> E["escalate_to_human\ncustom tool — creates ticket, sets state"]
+    F --> R
+    H --> R
+    E --> R
+    R --> U
+```
+
+### Project Structure
+
+```text
+src/
+├── server/
+│   ├── agents/
+│   │   ├── agent.ts               # LlmAgent builder with tools and session state
+│   │   └── tools.ts               # FileOperationsTool, HttpRequestTool, escalate_to_human
+│   ├── knowledge-base/
+│   │   ├── faq.md                 # General FAQs
+│   │   ├── refund-policy.md       # Return and refund policy
+│   │   └── shipping-info.md       # Shipping rates and timelines
+│   ├── index.ts                   # CLI entry point (readline loop)
+│   └── server.ts                  # HTTP server entry point (POST /chat)
+├── App.tsx                        # React chat UI
+├── App.css                        # Chat UI styles
+└── main.tsx                       # React entry point
+index.html
+vite.config.ts                     # Vite config with /chat proxy to localhost:3001
+```
+
+## Getting Started
+
+### Prerequisites
+
+- **Node.js 22+** — [Download Node.js](https://nodejs.org/en/download/)
+- **An API key** for your chosen model provider:
+  - [Google AI Studio](https://aistudio.google.com/app/api-keys) (default — Gemini)
+  - [OpenAI](https://platform.openai.com/api-keys)
+  - [Anthropic](https://console.anthropic.com/)
+
+### Installation
+
+1. Clone this repository
+
+```bash
+git clone https://github.com/IQAIcom/adk-ts-samples.git
+cd adk-ts-samples/apps/customer-support-agent
+```
+
+2. Install dependencies
+
+```bash
+pnpm install
+```
+
+3. Set up environment variables
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and add your API key:
+
+```env
+GOOGLE_API_KEY=your_google_api_key_here
+LLM_MODEL=gemini-2.5-flash
+```
+
+To use a different provider, swap the key and model:
+
+```env
+# OpenAI
+OPENAI_API_KEY=your_openai_api_key_here
+LLM_MODEL=gpt-4o
+
+# Anthropic
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+LLM_MODEL=claude-sonnet-4-6
+```
+
+### Running the Agent
+
+**Web chat UI** (server + frontend together):
+
+```bash
+pnpm dev
+```
+
+Open [http://localhost:5173](http://localhost:5173).
+
+**Terminal CLI** (no UI, just the agent in your terminal):
+
+```bash
+pnpm dev:cli
+```
+
+## Usage
+
+**Web UI** (`pnpm dev`) — type a message into the chat box and press Send. Use the example prompt buttons on first load to try common support scenarios.
+
+**CLI** (`pnpm dev:cli`) — type your question at the `You:` prompt and press Enter. Type `exit` to quit.
+
+```text
+You: What is your return policy?
+Agent: Based on our refund policy, you can return most items within 30 days of
+       delivery for a full refund...
+
+You: Where is my order? My order number is 3
+Agent: I checked your order and found the following items in cart #3: ...
+
+You: Look up my account, my user ID is 1
+Agent: I found your account: Terry Medhurst, terry.medhurst@example.com ...
+
+You: I need to speak to a human agent
+Agent: I've created a support ticket (TKT-ABC123) and a human agent will follow
+       up within 2 business hours. You'll receive an email confirmation shortly.
+```
+
+## Real-World Use Cases
+
+The **read policy → fetch live data → escalate** pattern in this project maps directly to real production support workflows. Here are examples of what you can build by extending this agent:
+
+### E-Commerce Support Bot
+
+Replace `dummyjson.com` with your own order management API and swap the markdown files for a headless CMS (Contentful, Sanity). The escalation tool opens a Zendesk or Freshdesk ticket via their REST APIs instead of logging to console.
+
+### SaaS Help Desk Agent
+
+Point `FileOperationsTool` at your docs folder or pipe in content from Notion or Confluence. Wire `HttpRequestTool` to your internal billing and subscription APIs to answer account-tier and usage questions without a human in the loop.
+
+### Internal IT Support Agent
+
+Replace the knowledge-base with IT runbooks and FAQs, and the HTTP tool with ServiceNow or Jira APIs. The escalation tool creates a proper IT ticket with the conversation transcript attached.
+
+### How to Adapt This Agent
+
+| Component              | What to Customize                                        | Example                                                      |
+| ---------------------- | -------------------------------------------------------- | ------------------------------------------------------------ |
+| **FileOperationsTool** | Swap markdown files for a CMS, vector store, or database | Replace with Pinecone semantic search for large policy bases |
+| **HttpRequestTool**    | Call your own authenticated APIs instead of the mock     | Add auth headers and call your real order management system  |
+| **escalate_to_human**  | Open a real ticket in your helpdesk instead of logging   | POST to Zendesk, Intercom, or Freshdesk with the transcript  |
+| **Session state**      | Add more state fields for your workflow (e.g. order ID)  | Track `current_order_id` so the agent doesn't ask twice      |
+
+## Useful Resources
+
+### ADK-TS Framework
+
+- [ADK-TS Documentation](https://adk.iqai.com/)
+- [ADK-TS CLI Documentation](https://adk.iqai.com/docs/cli)
+- [Built-in Tools Reference](https://adk.iqai.com/docs/framework/tools/built-in-tools)
+- [ADK-TS Samples Repository](https://github.com/IQAIcom/adk-ts-samples)
+- [ADK-TS GitHub Repository](https://github.com/IQAICOM/adk-ts)
+
+### APIs & Services
+
+- [Google AI Studio Keys](https://aistudio.google.com/app/api-keys)
+- [OpenAI API Keys](https://platform.openai.com/api-keys)
+- [Anthropic API Keys](https://console.anthropic.com/)
+
+### Community
+
+- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
+- [IQ AI Community](https://t.me/IQAICOM)
+
+## Contributing
+
+This Customer Support Agent is part of the [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples) repository, a collection of example projects demonstrating ADK-TS capabilities.
+
+We welcome contributions to the ADK-TS Samples repository! You can:
+
+- **Add new sample projects** showcasing different ADK-TS features
+- **Improve existing samples** with better documentation, new features, or optimizations
+- **Fix bugs** in current implementations
+- **Update dependencies** and keep samples current
+
+Please see our [Contributing Guide](../../CONTRIBUTION.md) for detailed guidelines.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.
+
+---
+
+**🎉 Ready to build your own support agent?** This project showcases how a single LlmAgent with two built-in tools, one custom tool, and a pinch of session state can handle the most common support flows — no complex orchestration needed.

--- a/apps/customer-support-agent/index.html
+++ b/apps/customer-support-agent/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Acme Corp Support</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/customer-support-agent/package.json
+++ b/apps/customer-support-agent/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "customer-support-agent",
+	"version": "1.0.0",
+	"description": "A customer support agent built with ADK-TS",
+	"scripts": {
+		"dev": "concurrently \"tsx src/server/server.ts\" \"vite\"",
+		"dev:cli": "tsx src/server/index.ts",
+		"dev:server": "tsx src/server/server.ts",
+		"dev:ui": "vite",
+		"build": "vite build",
+		"preview": "vite preview"
+	},
+	"private": true,
+	"dependencies": {
+		"@iqai/adk": "^0.8.5",
+		"dedent": "^1.7.0",
+		"dotenv": "^17.2.2",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"zod": "^4.1.5"
+	},
+	"devDependencies": {
+		"@types/node": "^24.3.1",
+		"@types/react": "^19.0.0",
+		"@types/react-dom": "^19.0.0",
+		"@vitejs/plugin-react": "^4.3.1",
+		"concurrently": "^9.0.0",
+		"tsx": "^4.20.5",
+		"typescript": "^5.9.2",
+		"vite": "^6.0.5"
+	},
+	"packageManager": "pnpm@10.0.0",
+	"engines": {
+		"node": ">=22.0"
+	}
+}

--- a/apps/customer-support-agent/src/App.css
+++ b/apps/customer-support-agent/src/App.css
@@ -1,0 +1,192 @@
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+body {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	background: #f0f2f5;
+	height: 100dvh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.app {
+	width: 100%;
+	max-width: 680px;
+	height: 100dvh;
+	max-height: 760px;
+	background: #fff;
+	border-radius: 16px;
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+/* Header */
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 16px 20px;
+	border-bottom: 1px solid #f0f0f0;
+	font-weight: 600;
+	font-size: 15px;
+	color: #111;
+}
+
+.header-dot {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: #22c55e;
+	flex-shrink: 0;
+}
+
+/* Messages */
+.messages {
+	flex: 1;
+	overflow-y: auto;
+	padding: 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.message {
+	display: flex;
+}
+
+.message.user {
+	justify-content: flex-end;
+}
+
+.bubble {
+	max-width: 75%;
+	padding: 10px 14px;
+	border-radius: 18px;
+	font-size: 14px;
+	line-height: 1.6;
+	white-space: pre-wrap;
+}
+
+.message.user .bubble {
+	background: #2563eb;
+	color: #fff;
+	border-bottom-right-radius: 4px;
+}
+
+.message.agent .bubble {
+	background: #f3f4f6;
+	color: #111;
+	border-bottom-left-radius: 4px;
+}
+
+/* Typing indicator */
+.bubble.typing {
+	display: flex;
+	gap: 5px;
+	align-items: center;
+	padding: 14px 16px;
+}
+
+.bubble.typing span {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: #9ca3af;
+	animation: bounce 1.2s infinite;
+}
+
+.bubble.typing span:nth-child(2) {
+	animation-delay: 0.2s;
+}
+
+.bubble.typing span:nth-child(3) {
+	animation-delay: 0.4s;
+}
+
+@keyframes bounce {
+	0%,
+	60%,
+	100% {
+		transform: translateY(0);
+	}
+	30% {
+		transform: translateY(-6px);
+	}
+}
+
+/* Example prompts */
+.examples {
+	padding: 0 20px 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.example-btn {
+	text-align: left;
+	background: #f9fafb;
+	border: 1px solid #e5e7eb;
+	border-radius: 10px;
+	padding: 10px 14px;
+	font-size: 13px;
+	color: #374151;
+	cursor: pointer;
+	transition: background 0.15s;
+}
+
+.example-btn:hover {
+	background: #eff1f5;
+}
+
+/* Input */
+.input-area {
+	display: flex;
+	gap: 10px;
+	padding: 16px 20px;
+	border-top: 1px solid #f0f0f0;
+}
+
+.input-area input {
+	flex: 1;
+	border: 1px solid #e5e7eb;
+	border-radius: 10px;
+	padding: 10px 14px;
+	font-size: 14px;
+	outline: none;
+	transition: border-color 0.15s;
+	font-family: inherit;
+}
+
+.input-area input:focus {
+	border-color: #2563eb;
+}
+
+.input-area button {
+	background: #2563eb;
+	color: #fff;
+	border: none;
+	border-radius: 10px;
+	padding: 10px 20px;
+	font-size: 14px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background 0.15s;
+	font-family: inherit;
+}
+
+.input-area button:hover:not(:disabled) {
+	background: #1d4ed8;
+}
+
+.input-area button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}

--- a/apps/customer-support-agent/src/App.tsx
+++ b/apps/customer-support-agent/src/App.tsx
@@ -1,0 +1,137 @@
+import { type FormEvent, useEffect, useRef, useState } from "react";
+
+interface Message {
+	id: string;
+	role: "user" | "agent";
+	text: string;
+}
+
+const EXAMPLES = [
+	"What is your return policy?",
+	"How much does shipping cost?",
+	"Can I return opened skin care products?",
+	"Where is my order? My order number is 3",
+	"Look up my account, my user ID is 1",
+	"I need to speak to a human agent",
+];
+
+export default function App() {
+	const [messages, setMessages] = useState<Message[]>([
+		{
+			id: crypto.randomUUID(),
+			role: "agent",
+			text: "Hi! I'm the Acme Corp support agent. How can I help you today?",
+		},
+	]);
+	const [input, setInput] = useState("");
+	const [loading, setLoading] = useState(false);
+	const bottomRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (messages.length > 0 || loading) {
+			bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+		}
+	}, [messages, loading]);
+
+	async function send(text: string) {
+		if (!text.trim() || loading) return;
+
+		setMessages((prev) => [
+			...prev,
+			{ id: crypto.randomUUID(), role: "user", text },
+		]);
+		setInput("");
+		setLoading(true);
+
+		try {
+			const res = await fetch("/chat", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ message: text }),
+			});
+			const data = await res.json();
+			setMessages((prev) => [
+				...prev,
+				{
+					id: crypto.randomUUID(),
+					role: "agent",
+					text: data.response ?? data.error ?? "Something went wrong.",
+				},
+			]);
+		} catch {
+			setMessages((prev) => [
+				...prev,
+				{
+					id: crypto.randomUUID(),
+					role: "agent",
+					text: "Connection error. Is the server running?",
+				},
+			]);
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	function onSubmit(e: FormEvent) {
+		e.preventDefault();
+		send(input);
+	}
+
+	const showExamples = messages.length === 1;
+
+	return (
+		<div className="app">
+			<header className="header">
+				<div className="header-dot" />
+				<span>Acme Corp Support</span>
+			</header>
+
+			<div className="messages">
+				{messages.map((m) => (
+					<div key={m.id} className={`message ${m.role}`}>
+						<div className="bubble">{m.text}</div>
+					</div>
+				))}
+
+				{loading && (
+					<div className="message agent">
+						<div className="bubble typing">
+							<span />
+							<span />
+							<span />
+						</div>
+					</div>
+				)}
+
+				<div ref={bottomRef} />
+			</div>
+
+			{showExamples && (
+				<div className="examples">
+					{EXAMPLES.map((ex) => (
+						<button
+							key={ex}
+							className="example-btn"
+							onClick={() => send(ex)}
+							type="button"
+						>
+							{ex}
+						</button>
+					))}
+				</div>
+			)}
+
+			<form className="input-area" onSubmit={onSubmit}>
+				<input
+					value={input}
+					onChange={(e) => setInput(e.target.value)}
+					placeholder="Type your message..."
+					disabled={loading}
+				/>
+				<button type="submit" disabled={loading || !input.trim()}>
+					Send
+				</button>
+			</form>
+		</div>
+	);
+}

--- a/apps/customer-support-agent/src/main.tsx
+++ b/apps/customer-support-agent/src/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+import "./App.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("Root element not found");
+createRoot(rootEl).render(
+	<StrictMode>
+		<App />
+	</StrictMode>,
+);

--- a/apps/customer-support-agent/src/server/agents/agent.ts
+++ b/apps/customer-support-agent/src/server/agents/agent.ts
@@ -1,0 +1,61 @@
+import { AgentBuilder } from "@iqai/adk";
+import dedent from "dedent";
+import {
+	escalateToHumanTool,
+	httpRequestTool,
+	knowledgeBaseTool,
+} from "./tools";
+
+export function getRootAgent() {
+	const initialState = {
+		escalated: false,
+	};
+
+	return AgentBuilder.create("acme_support_agent")
+		.withModel(process.env.LLM_MODEL || "gemini-2.5-flash")
+		.withInstruction(
+			dedent`
+				You are a friendly and professional customer support agent for Acme Corp, an online
+				marketplace selling a wide range of products including smartphones, laptops, tablets,
+				mobile accessories, beauty and skin care, fragrances, fashion (clothing, shoes, watches,
+				bags, jewellery), home decoration, furniture, kitchen accessories, groceries, sports
+				accessories, and vehicles.
+
+				## How to handle requests
+
+				**Policy and product questions** (shipping, returns, payments, membership, etc.)
+				  Use file_operations to answer these:
+				  1. Call file_operations with operation:"list", filepath:"." to see available documents.
+				  2. Read the most relevant file with operation:"read", filepath:"<filename>".
+				  3. Answer strictly from what the file says — never invent policy details.
+
+				**Order status** — use http_request to fetch live order data:
+				  - Ask the customer for their order number if not provided (e.g. 1, 2, 3).
+				  - Call GET https://dummyjson.com/carts/<number> replacing <number> with the order number.
+				  - Summarise the cart items, total, and any relevant details for the customer.
+
+				**Account / user lookup** — use http_request to fetch live user data:
+				  - Ask the customer for their user ID if not provided.
+				  - Call GET https://dummyjson.com/users/<number> replacing <number> with the user ID.
+				  - Share their name, email, address, and any relevant account details.
+
+				**Escalation** — call escalate_to_human when:
+				  - The customer asks to speak to a human.
+				  - You cannot resolve the issue after two attempts.
+				  - The issue involves billing disputes, account suspension, or fraud.
+				  - The customer is clearly frustrated.
+
+				## Tone
+				- Be warm, empathetic, and concise.
+				- Acknowledge the customer's concern before jumping to a solution.
+				- Confirm what you looked up (e.g. "I checked your order and…").
+				- Keep replies under 3 short paragraphs unless more detail is needed.
+
+				## Session state
+				- Escalated: {escalated}
+			`,
+		)
+		.withTools(knowledgeBaseTool, httpRequestTool, escalateToHumanTool)
+		.withQuickSession({ state: initialState })
+		.build();
+}

--- a/apps/customer-support-agent/src/server/agents/tools.ts
+++ b/apps/customer-support-agent/src/server/agents/tools.ts
@@ -1,0 +1,51 @@
+import * as path from "node:path";
+import { FileOperationsTool, HttpRequestTool, createTool } from "@iqai/adk";
+import * as z from "zod";
+
+// Gives the agent read access to markdown files in the knowledge-base directory (FAQs, policies, shipping info).
+// In real life, this would point to a CMS, a database, or an internal knowledge management system (e.g. Notion, Confluence, or a vector store for semantic search).
+export const knowledgeBaseTool = new FileOperationsTool({
+	basePath: path.join(process.cwd(), "src", "server", "knowledge-base"),
+});
+
+// Allows the agent to make outbound HTTP requests to fetch live data such as order status or user account info.
+// In real life, this would call your own authenticated backend APIs rather than a public mock API, and would include auth headers, error handling, and rate limiting.
+export const httpRequestTool = new HttpRequestTool();
+
+// Creates a support ticket and flags the session for human follow-up.
+// In real life, this would open a ticket in a helpdesk system (e.g. Zendesk, Intercom, or Freshdesk), notify an agent via Slack or email, and store the conversation transcript.
+export const escalateToHumanTool = createTool({
+	name: "escalate_to_human",
+	description:
+		"Escalate this conversation to a human support agent. Use this when: the customer is frustrated, the issue cannot be resolved automatically, the customer explicitly requests a human, or you have failed to resolve the issue after 2 attempts.",
+	schema: z.object({
+		reason: z.string().describe("Why this conversation needs a human agent"),
+		summary: z
+			.string()
+			.describe(
+				"A concise summary of the conversation and the unresolved issue for the human agent",
+			),
+	}),
+	fn: ({ reason, summary }, context) => {
+		context.state.set("escalated", true);
+
+		const ticketId = `TKT-${Date.now().toString(36).toUpperCase()}`;
+		const timestamp = new Date().toISOString();
+
+		console.log("\n--- ESCALATION TICKET CREATED ---");
+		console.log(`Ticket ID : ${ticketId}`);
+		console.log(`Timestamp : ${timestamp}`);
+		console.log(`Reason    : ${reason}`);
+		console.log(`Summary   : ${summary}`);
+		console.log("---------------------------------\n");
+
+		return {
+			escalated: true,
+			ticketId,
+			message:
+				"I've created a support ticket and a human agent will follow up with you within 2 business hours. Your ticket ID is " +
+				ticketId +
+				". You'll receive an email confirmation shortly.",
+		};
+	},
+});

--- a/apps/customer-support-agent/src/server/index.ts
+++ b/apps/customer-support-agent/src/server/index.ts
@@ -1,0 +1,61 @@
+import * as readline from "node:readline";
+import "dotenv/config";
+import { getRootAgent } from "./agents/agent";
+
+async function main() {
+	const { runner } = await getRootAgent();
+
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+
+	console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+	console.log("  Acme Corp Customer Support  |  Powered by ADK-TS  ");
+	console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+	console.log('Type your question and press Enter. Type "exit" to quit.\n');
+	console.log("Example questions to try:");
+	console.log("  • What is your return policy?");
+	console.log("  • How much does shipping cost?");
+	console.log("  • Where is my order? My order number is 3");
+	console.log("  • Look up my account, my user ID is 1");
+	console.log("  • I need to speak to a human agent");
+	console.log("");
+
+	const prompt = () => {
+		rl.question("You: ", async (input) => {
+			const trimmed = input.trim();
+
+			if (!trimmed) {
+				prompt();
+				return;
+			}
+
+			if (trimmed.toLowerCase() === "exit") {
+				console.log("\nThank you for contacting Acme Corp support. Goodbye!\n");
+				rl.close();
+				return;
+			}
+
+			try {
+				const response = await runner.ask(trimmed);
+				console.log(`\nAgent: ${response}\n`);
+			} catch (err) {
+				console.error(
+					"\nAgent error:",
+					err instanceof Error ? err.message : err,
+					"\n",
+				);
+			}
+
+			prompt();
+		});
+	};
+
+	prompt();
+}
+
+main().catch((err) => {
+	console.error("Fatal error:", err);
+	process.exit(1);
+});

--- a/apps/customer-support-agent/src/server/knowledge-base/faq.md
+++ b/apps/customer-support-agent/src/server/knowledge-base/faq.md
@@ -1,0 +1,50 @@
+# Frequently Asked Questions — Acme Corp
+
+## What is Acme Corp?
+
+Acme Corp is an online marketplace selling a wide range of products across electronics (smartphones, laptops, tablets, mobile accessories), fashion (clothing, shoes, watches, bags, jewellery), beauty and skin care, fragrances, home decoration, furniture, kitchen accessories, groceries, sports accessories, and vehicles. We ship worldwide and offer a 30-day return window on all products.
+
+## How do I create an account?
+
+Visit acmecorp.com and click "Sign Up" in the top right corner. You'll need a valid email address and a password. Account creation is free and takes less than two minutes.
+
+## What payment methods do you accept?
+
+We accept all major credit cards (Visa, Mastercard, AmEx, Discover), PayPal, Apple Pay, Google Pay, and Acme gift cards. We do not accept cash, checks, or cryptocurrency.
+
+## Can I change or cancel my order?
+
+Orders can be changed or cancelled within 1 hour of placement as long as they have not yet entered the "processing" status. After that point the order cannot be modified. Contact support immediately if you need to cancel.
+
+## How do I track my order?
+
+Log in to your account and go to "My Orders". Click on the order to see real-time tracking. You can also provide your order ID to our support team and we can look it up for you.
+
+## Do you offer gift wrapping?
+
+Yes, gift wrapping is available for $4.99 per item. Select "Gift Wrap" during checkout. You can also add a personalised message.
+
+## What are your customer support hours?
+
+Our AI support agent is available 24/7. Human agents are available Monday–Friday 9am–6pm EST and Saturday 10am–4pm EST.
+
+## How do I apply a promo code?
+
+Enter your promo code in the "Discount Code" field at checkout before completing payment. Promo codes cannot be applied after an order is placed.
+
+## Do you have a loyalty program?
+
+Yes! Every dollar spent earns 1 loyalty point. Points can be redeemed at checkout at a rate of 100 points = $1 off. Pro plan members earn 2x points on every purchase.
+
+## What are the membership plan differences?
+
+- **Basic Plan** (free): Standard shipping speeds, 1x loyalty points, standard support.
+- **Pro Plan** ($9.99/month): Free 2-day shipping, 2x loyalty points, priority support, early access to sales.
+
+## How do I upgrade my plan?
+
+Log in and go to Account Settings → Membership. Click "Upgrade to Pro" and enter your payment details.
+
+## Is my payment information secure?
+
+Yes. We use 256-bit SSL encryption and are PCI DSS compliant. We never store your full card number — only a tokenized reference.

--- a/apps/customer-support-agent/src/server/knowledge-base/refund-policy.md
+++ b/apps/customer-support-agent/src/server/knowledge-base/refund-policy.md
@@ -1,0 +1,58 @@
+# Refund and Return Policy — Acme Corp
+
+## Return Window
+
+All products are eligible for return within **30 days** of the delivery date. Items must be unused, in original packaging, and include all accessories and documentation.
+
+## How to Start a Return
+
+1. Log in to your account and go to "My Orders".
+2. Select the order and click "Return Item".
+3. Choose your reason for return and print the prepaid return label.
+4. Drop the package at any UPS or FedEx location.
+
+Returns can also be initiated by contacting our support team with your order ID.
+
+## Refund Timeline
+
+- Once we receive your returned item, we inspect it within 2 business days.
+- Approved refunds are processed within 3–5 business days.
+- The refund appears on your original payment method within 5–10 business days depending on your bank.
+
+## Refund Methods
+
+Refunds are issued to the original payment method used at checkout. We do not offer cash refunds. If you paid with an Acme gift card, the refund is returned to the gift card balance.
+
+## Non-Returnable Items
+
+The following items cannot be returned:
+
+- Opened software or digital licenses
+- Customised or engraved products
+- Hygiene and personal care products (earbuds, beauty tools, skin care, grooming items, fragrances) once opened
+- Food, groceries, and perishable items
+- Vehicles and motorcycles once registered or ridden
+- Items marked "Final Sale" at checkout
+
+## Damaged or Defective Items
+
+If your item arrived damaged or is defective, contact us within 7 days of delivery. We will send a replacement at no cost or issue a full refund — your choice. Please attach a photo of the damage when contacting support.
+
+## Wrong Item Received
+
+If you received the wrong item, contact us within 14 days. We will arrange free return shipping and send the correct item immediately.
+
+## Partial Refunds
+
+Partial refunds may be issued for:
+
+- Items returned without original packaging (up to 15% restocking fee)
+- Items with visible wear or use
+
+## Exchange Policy
+
+We do not offer direct exchanges. To get a different product, return the original item for a refund and place a new order.
+
+## Cancellations
+
+Orders cancelled within 1 hour of placement receive a full refund within 24 hours. Orders cancelled after shipment must go through the standard return process.

--- a/apps/customer-support-agent/src/server/knowledge-base/shipping-info.md
+++ b/apps/customer-support-agent/src/server/knowledge-base/shipping-info.md
@@ -1,0 +1,57 @@
+# Shipping Information — Acme Corp
+
+## Shipping Options and Costs
+
+| Method                 | Estimated Delivery | Cost                    |
+| ---------------------- | ------------------ | ----------------------- |
+| Standard Shipping      | 5–7 business days  | $4.99                   |
+| Expedited Shipping     | 2–3 business days  | $9.99                   |
+| Overnight Shipping     | Next business day  | $24.99                  |
+| Free Standard Shipping | 5–7 business days  | Free on orders over $50 |
+
+**Pro Plan members** receive free 2-day shipping on all orders automatically.
+
+## Processing Time
+
+Orders placed before 2pm EST Monday–Friday are processed the same day. Orders placed after 2pm EST or on weekends are processed the next business day. Processing typically takes 1 business day before the item ships.
+
+## Carriers
+
+We ship via FedEx, UPS, and USPS depending on your location and selected shipping method. The carrier is assigned automatically at the time of shipment.
+
+## Tracking Your Shipment
+
+A tracking number is emailed to you as soon as your order ships. You can also find it in "My Orders" in your account. Allow up to 24 hours for the tracking number to become active in the carrier's system.
+
+## International Shipping
+
+We ship to over 50 countries. International shipping rates and delivery times vary by destination:
+
+- **Canada**: 7–10 business days, starting at $12.99
+- **UK / Europe**: 10–14 business days, starting at $19.99
+- **Australia / New Zealand**: 12–16 business days, starting at $24.99
+- **Rest of World**: 14–21 business days, starting at $29.99
+
+International customers are responsible for any customs duties, taxes, or import fees charged by their country.
+
+## Address Changes
+
+Address changes can be made within 1 hour of placing the order, before processing begins. Contact support immediately with your order ID and the new address.
+
+## Undeliverable Packages
+
+If a package is returned to us as undeliverable (wrong address, unclaimed, etc.), we will contact you to arrange re-shipment. Re-shipment incurs a new shipping fee.
+
+## Lost or Stolen Packages
+
+If tracking shows "delivered" but you have not received your package:
+
+1. Check with neighbours and around your property.
+2. Wait 24 hours — carriers sometimes mark delivered early.
+3. If still not found after 24 hours, contact us and we will file a carrier claim.
+
+We will offer a replacement or refund once the carrier investigation is complete (typically 5–7 business days).
+
+## Holiday Shipping Cutoffs
+
+During peak holiday seasons (November–December), we recommend ordering at least 10 business days before your required delivery date to account for carrier delays. Cutoff dates for guaranteed Christmas delivery are announced each November.

--- a/apps/customer-support-agent/src/server/server.ts
+++ b/apps/customer-support-agent/src/server/server.ts
@@ -1,0 +1,65 @@
+import http from "node:http";
+import "dotenv/config";
+import { getRootAgent } from "./agents/agent";
+
+const PORT = process.env.PORT ?? 3001;
+
+async function main() {
+	const { runner } = await getRootAgent();
+
+	const server = http.createServer(async (req, res) => {
+		res.setHeader("Access-Control-Allow-Origin", "*");
+		res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+		res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+		if (req.method === "OPTIONS") {
+			res.writeHead(204);
+			res.end();
+			return;
+		}
+
+		if (req.method === "POST" && req.url === "/chat") {
+			let body = "";
+			req.on("data", (chunk) => {
+				body += chunk;
+			});
+			req.on("end", async () => {
+				try {
+					const { message } = JSON.parse(body);
+
+					if (!message?.trim()) {
+						res.writeHead(400, { "Content-Type": "application/json" });
+						res.end(JSON.stringify({ error: "message is required" }));
+						return;
+					}
+
+					const response = await runner.ask(message.trim());
+					res.writeHead(200, { "Content-Type": "application/json" });
+					res.end(JSON.stringify({ response }));
+				} catch (err) {
+					res.writeHead(500, { "Content-Type": "application/json" });
+					res.end(
+						JSON.stringify({
+							error:
+								err instanceof Error ? err.message : "Internal server error",
+						}),
+					);
+				}
+			});
+			return;
+		}
+
+		res.writeHead(404);
+		res.end();
+	});
+
+	server.listen(PORT, () => {
+		console.log(`API server → http://localhost:${PORT}`);
+		console.log('Run "pnpm dev" to start both server and UI together.');
+	});
+}
+
+main().catch((err) => {
+	console.error("Fatal error:", err);
+	process.exit(1);
+});

--- a/apps/customer-support-agent/src/server/server.ts
+++ b/apps/customer-support-agent/src/server/server.ts
@@ -3,63 +3,81 @@ import "dotenv/config";
 import { getRootAgent } from "./agents/agent";
 
 const PORT = process.env.PORT ?? 3001;
+const BODY_SIZE_LIMIT = 1e6; // 1 MB
 
-async function main() {
-	const { runner } = await getRootAgent();
+const server = http.createServer(async (req, res) => {
+	res.setHeader("Access-Control-Allow-Origin", "*");
+	res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+	res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
-	const server = http.createServer(async (req, res) => {
-		res.setHeader("Access-Control-Allow-Origin", "*");
-		res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-		res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-
-		if (req.method === "OPTIONS") {
-			res.writeHead(204);
-			res.end();
-			return;
-		}
-
-		if (req.method === "POST" && req.url === "/chat") {
-			let body = "";
-			req.on("data", (chunk) => {
-				body += chunk;
-			});
-			req.on("end", async () => {
-				try {
-					const { message } = JSON.parse(body);
-
-					if (!message?.trim()) {
-						res.writeHead(400, { "Content-Type": "application/json" });
-						res.end(JSON.stringify({ error: "message is required" }));
-						return;
-					}
-
-					const response = await runner.ask(message.trim());
-					res.writeHead(200, { "Content-Type": "application/json" });
-					res.end(JSON.stringify({ response }));
-				} catch (err) {
-					res.writeHead(500, { "Content-Type": "application/json" });
-					res.end(
-						JSON.stringify({
-							error:
-								err instanceof Error ? err.message : "Internal server error",
-						}),
-					);
-				}
-			});
-			return;
-		}
-
-		res.writeHead(404);
+	if (req.method === "OPTIONS") {
+		res.writeHead(204);
 		res.end();
-	});
+		return;
+	}
 
-	server.listen(PORT, () => {
-		console.log(`API server → http://localhost:${PORT}`);
-		console.log('Run "pnpm dev" to start both server and UI together.');
-	});
-}
+	const pathname = new URL(req.url ?? "", "http://localhost").pathname;
 
-main().catch((err) => {
-	console.error("Fatal error:", err);
+	if (req.method === "POST" && pathname === "/chat") {
+		let body = "";
+		let aborted = false;
+
+		req.on("data", (chunk) => {
+			body += chunk;
+			if (body.length > BODY_SIZE_LIMIT) {
+				aborted = true;
+				res.writeHead(413, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ error: "Payload too large" }));
+				req.destroy();
+			}
+		});
+
+		req.on("end", async () => {
+			if (aborted) return;
+			try {
+				const { message } = JSON.parse(body);
+
+				if (!message?.trim()) {
+					res.writeHead(400, { "Content-Type": "application/json" });
+					res.end(JSON.stringify({ error: "message is required" }));
+					return;
+				}
+
+				// Each request gets its own runner so session state (e.g. escalated flag)
+				// is isolated per conversation rather than shared across all users.
+				const { runner } = await getRootAgent();
+				const response = await runner.ask(message.trim());
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ response }));
+			} catch (err) {
+				const isJsonError = err instanceof SyntaxError;
+				res.writeHead(isJsonError ? 400 : 500, {
+					"Content-Type": "application/json",
+				});
+				res.end(
+					JSON.stringify({
+						error: isJsonError
+							? "Invalid JSON payload"
+							: err instanceof Error
+								? err.message
+								: "Internal server error",
+					}),
+				);
+			}
+		});
+		return;
+	}
+
+	res.writeHead(404);
+	res.end();
+});
+
+server.listen(PORT, () => {
+	console.log(`API server → http://localhost:${PORT}`);
+	console.log('Run "pnpm dev" to start both server and UI together.');
+});
+
+server.on("error", (err) => {
+	console.error("Fatal server error:", err);
 	process.exit(1);
 });

--- a/apps/customer-support-agent/src/vite-env.d.ts
+++ b/apps/customer-support-agent/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/customer-support-agent/tsconfig.json
+++ b/apps/customer-support-agent/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
+		"moduleResolution": "Bundler",
+		"skipLibCheck": true,
+		"strict": false,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"jsx": "react-jsx",
+		"moduleDetection": "force",
+		"types": ["node"]
+	},
+	"include": ["src", "vite.config.ts"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/apps/customer-support-agent/vite.config.ts
+++ b/apps/customer-support-agent/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+	plugins: [react()],
+	server: {
+		proxy: {
+			"/chat": "http://localhost:3001",
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,52 @@ importers:
         specifier: ^5.9.2
         version: 5.9.3
 
+  apps/customer-support-agent:
+    dependencies:
+      '@iqai/adk':
+        specifier: ^0.8.5
+        version: 0.8.5(@opentelemetry/instrumentation-nestjs-core@0.55.0(@opentelemetry/api@1.9.0))(@types/node@24.11.0)(@types/pg@8.15.6)(bufferutil@4.1.0)(hono@4.12.3)(langfuse@3.38.6)(pg@8.19.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      dedent:
+        specifier: ^1.7.0
+        version: 1.7.2
+      dotenv:
+        specifier: ^17.2.2
+        version: 17.3.1
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.0(react@19.1.0)
+      zod:
+        specifier: ^4.1.5
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.1
+        version: 24.11.0
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.1
+        version: 4.7.0(vite@6.4.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      concurrently:
+        specifier: ^9.0.0
+        version: 9.2.1
+      tsx:
+        specifier: ^4.20.5
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.5
+        version: 6.4.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
   apps/dao-proposal-analyzer:
     dependencies:
       '@iqai/adk':
@@ -318,8 +364,91 @@ packages:
     resolution: {integrity: sha512-GnlOXrPxow0uoaVB3DGNh9EJBU1MyagCBCLpU+bwDVlj/oOPYIwoiasMWlykkfYcQOrDP2x/zHnRD0xN7PeZPw==}
     hasBin: true
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@balena/dockerignore@1.0.2':
@@ -412,16 +541,34 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -430,16 +577,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -448,10 +613,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -460,10 +637,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -472,10 +661,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -484,10 +685,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -496,10 +709,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.3':
@@ -508,16 +733,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.3':
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.3':
@@ -526,10 +769,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -538,11 +793,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
@@ -550,16 +817,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.3':
@@ -2094,6 +2379,9 @@ packages:
   '@reown/appkit@1.7.8':
     resolution: {integrity: sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==}
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -2990,6 +3278,18 @@ packages:
   '@types/aws-lambda@8.10.161':
     resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/bunyan@1.8.11':
     resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
 
@@ -3079,6 +3379,12 @@ packages:
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@wagmi/connectors@6.2.0':
     resolution: {integrity: sha512-2NfkbqhNWdjfibb4abRMrn7u6rPjEGolMfApXss6HCDVt9AW2oVC6k8Q5FouzpJezElxLJSagWz9FW1zaRlanA==}
@@ -3365,6 +3671,11 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
+  baseline-browser-mapping@2.10.29:
+    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
@@ -3400,6 +3711,11 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
@@ -3545,6 +3861,11 @@ packages:
     engines: {node: ^14.13.0 || >=16.0.0}
     hasBin: true
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -3559,6 +3880,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
@@ -3826,6 +4150,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.353:
+    resolution: {integrity: sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -3888,6 +4215,11 @@ packages:
 
   es6-promisify@5.0.0:
     resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -4102,6 +4434,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -4337,6 +4673,14 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -4358,6 +4702,11 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonrepair@3.13.2:
     resolution: {integrity: sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==}
@@ -4510,6 +4859,9 @@ packages:
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lucide-react@0.546.0:
     resolution: {integrity: sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ==}
@@ -4681,6 +5033,9 @@ packages:
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -5042,6 +5397,10 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -5154,6 +5513,10 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -5614,6 +5977,12 @@ packages:
       uploadthing:
         optional: true
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   use-sync-external-store@1.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
@@ -5691,6 +6060,46 @@ packages:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
+        optional: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   wagmi@2.19.5:
@@ -5823,6 +6232,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
@@ -5946,7 +6358,119 @@ snapshots:
 
   '@anthropic-ai/sdk@0.61.0': {}
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/runtime@7.28.6': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@balena/dockerignore@1.0.2': {}
 
@@ -6091,79 +6615,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
@@ -6724,6 +7326,88 @@ snapshots:
       openai: 5.23.2(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       socket.io: 4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       ts-node: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
+      uuid: 13.0.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/instrumentation-nestjs-core': 0.55.0(@opentelemetry/api@1.9.0)
+      langfuse: 3.38.6
+      pg: 8.19.0
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cfworker/json-schema'
+      - '@cloudflare/workers-types'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/node'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - babel-plugin-macros
+      - bufferutil
+      - bun-types
+      - debug
+      - encoding
+      - expo-sqlite
+      - gel
+      - hono
+      - knex
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@iqai/adk@0.8.5(@opentelemetry/instrumentation-nestjs-core@0.55.0(@opentelemetry/api@1.9.0))(@types/node@24.11.0)(@types/pg@8.15.6)(bufferutil@4.1.0)(hono@4.12.3)(langfuse@3.38.6)(pg@8.19.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@anthropic-ai/sdk': 0.61.0
+      '@clack/prompts': 0.11.0
+      '@electric-sql/pglite': 0.3.15
+      '@google-cloud/storage': 7.19.0
+      '@google-cloud/vertexai': 1.10.0
+      '@google/genai': 1.43.0(@modelcontextprotocol/sdk@1.25.1(hono@4.12.3)(zod@4.3.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@modelcontextprotocol/sdk': 1.25.1(hono@4.12.3)(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/auto-instrumentations-node': 0.67.3(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))
+      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.209.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-openai': 0.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/cors': 2.8.19
+      ai: 5.0.141(zod@4.3.6)
+      axios: 1.13.6
+      chalk: 5.6.2
+      cors: 2.8.6
+      croner: 10.0.1
+      dedent: 1.7.2
+      dockerode: 4.0.9
+      dotenv: 17.3.1
+      drizzle-orm: 0.44.7(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.11)(pg@8.19.0)
+      google-auth-library: 9.15.1
+      jsonrepair: 3.13.2
+      kysely: 0.28.11
+      openai: 5.23.2(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
+      socket.io: 4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ts-node: 10.9.2(@types/node@24.11.0)(typescript@5.9.3)
       uuid: 13.0.0
       zod: 4.3.6
     optionalDependencies:
@@ -8755,6 +9439,8 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -9816,6 +10502,27 @@ snapshots:
 
   '@types/aws-lambda@8.10.161': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/bunyan@1.8.11':
     dependencies:
       '@types/node': 24.11.0
@@ -9916,6 +10623,18 @@ snapshots:
       '@types/node': 24.11.0
 
   '@vercel/oidc@3.1.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@wagmi/connectors@6.2.0(@tanstack/react-query@5.90.21(react@19.1.0))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@6.0.6)(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.1.0))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
@@ -10674,6 +11393,8 @@ snapshots:
 
   base64id@2.0.0: {}
 
+  baseline-browser-mapping@2.10.29: {}
+
   bcrypt-pbkdf@1.0.2:
     dependencies:
       tweetnacl: 0.14.5
@@ -10723,6 +11444,14 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001788
+      electron-to-chromium: 1.5.353
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bs58@4.0.1:
     dependencies:
@@ -10863,6 +11592,15 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
@@ -10870,6 +11608,8 @@ snapshots:
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.2: {}
 
@@ -11033,6 +11773,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  electron-to-chromium@1.5.353: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -11106,6 +11848,35 @@ snapshots:
   es6-promisify@5.0.0:
     dependencies:
       es6-promise: 4.2.8
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -11383,6 +12154,8 @@ snapshots:
 
   generator-function@2.0.1: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
@@ -11657,6 +12430,10 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -11675,6 +12452,8 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stringify-safe@5.0.1: {}
+
+  json5@2.2.3: {}
 
   jsonrepair@3.13.2: {}
 
@@ -11818,6 +12597,10 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lucide-react@0.546.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -11954,6 +12737,8 @@ snapshots:
   node-gyp-build@4.8.4: {}
 
   node-mock-http@1.0.4: {}
+
+  node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
 
@@ -12342,6 +13127,8 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-refresh@0.17.0: {}
+
   react@19.1.0: {}
 
   readable-stream@2.3.8:
@@ -12497,6 +13284,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   scheduler@0.26.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -12999,6 +13788,12 @@ snapshots:
     optionalDependencies:
       idb-keyval: 6.2.2
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   use-sync-external-store@1.2.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -13116,6 +13911,22 @@ snapshots:
       - bufferutil
       - utf-8-validate
       - zod
+
+  vite@6.4.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.10
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.11.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.8.2
 
   wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.1.0))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))(zod@4.3.6):
     dependencies:
@@ -13423,6 +14234,8 @@ snapshots:
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.8.2: {}
 


### PR DESCRIPTION
## Summary

- Adds a new `customer-support-agent` app to the monorepo — a fullstack customer support chatbot for Acme Corp built with a single ADK-TS `LlmAgent`
- Demonstrates `FileOperationsTool` (policy Q&A from markdown files), `HttpRequestTool` (live order and account lookup), and a custom `escalate_to_human` tool with session state
- Ships with two run modes: React + Vite web chat UI (`pnpm dev`) and an interactive terminal CLI (`pnpm dev:cli`)

## Changes

- **`apps/customer-support-agent/`** — new agent with fullstack setup (React/Vite frontend + Node HTTP server + ADK-TS agent)
- **`README.md`** — added agent to the Available Samples table
- **`pnpm-lock.yaml`** — updated to include the new agent's dependencies

## Monorepo integration fixes applied

- Script paths corrected (`server/` → `src/server/`)
- `packageManager` aligned to `pnpm@10.0.0`
- `tsconfig.json` include fixed (removed phantom `server` entry)
- App-level `pnpm-lock.yaml` removed; dependencies merged into the root lockfile
- Biome lint errors fixed in `App.tsx` and `main.tsx` (non-null assertion, array index key, exhaustive deps, autoFocus)

## Test plan

- [ ] `pnpm dev` from `apps/customer-support-agent/` starts both the Node server (port 3001) and Vite (port 5173)
- [ ] Chat UI loads at http://localhost:5173 and example prompts work
- [ ] Policy questions (return policy, shipping cost) are answered from the knowledge-base files
- [ ] Order lookup (`order number is 3`) and account lookup (`user ID is 1`) hit the live API
- [ ] Escalation request creates a ticket and sets session state
- [ ] `pnpm dev:cli` starts the terminal CLI and accepts typed input
- [ ] `pnpm build` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)