### PR TITLE
chore: rename IQAICOM/IQAIcom to IQOfficial

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://adk.iqai.com/docs
     about: Check the official ADK-TS documentation for framework guides and API references
   - name: Main ADK-TS Repository
-    url: https://github.com/IQAIcom/adk-ts
+    url: https://github.com/IQOfficial/adk-ts
     about: Report framework bugs or feature requests in the main repository
   - name: GitHub Discussions
-    url: https://github.com/IQAIcom/adk-ts/discussions
+    url: https://github.com/IQOfficial/adk-ts/discussions
     about: Engage with the community to ask questions, share ideas, and get help

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -32,7 +32,7 @@ Before contributing, we encourage you to read our [Code of Conduct](CODE_OF_COND
 
 This section guides you through submitting a bug report for existing samples. Following these guidelines helps maintainers and the community understand your report, reproduce the behavior, and find related reports.
 
-Before creating a new issue, **[check existing issues](https://github.com/IQAIcom/adk-ts-samples/issues)** to see if the report exists. If it does, go through the discussion thread and leave a comment instead of opening a new one.
+Before creating a new issue, **[check existing issues](https://github.com/IQOfficial/adk-ts-samples/issues)** to see if the report exists. If it does, go through the discussion thread and leave a comment instead of opening a new one.
 
 If you find a **Closed** issue that is the same as what you are experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
@@ -53,7 +53,7 @@ When reporting issues with samples, be sure to include:
 
 We track new sample requests as GitHub issues using the "Sample Request" template.
 
-Before submitting a new sample request, **[check existing issues](https://github.com/IQAIcom/adk-ts-samples/issues)** to see if a similar request already exists.
+Before submitting a new sample request, **[check existing issues](https://github.com/IQOfficial/adk-ts-samples/issues)** to see if a similar request already exists.
 
 A good sample request should include:
 
@@ -143,7 +143,7 @@ You can contribute by:
 
 #### 1. Fork the repo
 
-Click the fork button at the top right of the [project home page](https://github.com/IQAIcom/adk-ts-samples) to create a copy of this repo in your account.
+Click the fork button at the top right of the [project home page](https://github.com/IQOfficial/adk-ts-samples) to create a copy of this repo in your account.
 
 #### 2. Clone the forked repo
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
   <i>Sample Projects • Agent Samples • Learning Resources</i>
 
   <p align="center">
-    <a href="https://github.com/IQAIcom/adk-ts/blob/main/LICENSE.md">
+    <a href="https://github.com/IQOfficial/adk-ts/blob/main/LICENSE.md">
       <img src="https://img.shields.io/npm/l/@iqai/adk" alt="License" />
     </a>
-    <a href="https://github.com/IQAIcom/adk-ts-samples">
-      <img src="https://img.shields.io/github/stars/IQAIcom/adk-ts-samples?style=social" alt="GitHub Stars" />
+    <a href="https://github.com/IQOfficial/adk-ts-samples">
+      <img src="https://img.shields.io/github/stars/IQOfficial/adk-ts-samples?style=social" alt="GitHub Stars" />
     </a>
   </p>
 </div>
@@ -28,7 +28,7 @@ This repository contains ADK-TS sample agents and projects. Navigate to the **[a
 > [!IMPORTANT]  
 > The samples in this repository are built using **ADK-TS**. Before you can run any of the samples, you must have ADK-TS installed. For instructions, please refer to the [**ADK-TS Installation Guide**](https://adk.iqai.com/docs/framework/get-started/installation).
 
-To learn more, check out the [ADK-TS Documentation](https://adk.iqai.com/docs), and the main [ADK-TS GitHub repository](https://github.com/IQAIcom/adk-ts).
+To learn more, check out the [ADK-TS Documentation](https://adk.iqai.com/docs), and the main [ADK-TS GitHub repository](https://github.com/IQOfficial/adk-ts).
 
 ## 🌳 Repository Structure
 
@@ -42,7 +42,7 @@ To learn more, check out the [ADK-TS Documentation](https://adk.iqai.com/docs), 
 
 ## ℹ️ Getting Help
 
-If you have any questions or if you found any problems with this repository, please report through [GitHub issues](https://github.com/IQAIcom/adk-ts-samples/issues).
+If you have any questions or if you found any problems with this repository, please report through [GitHub issues](https://github.com/IQOfficial/adk-ts-samples/issues).
 
 ## 🚀 Getting Started
 
@@ -57,7 +57,7 @@ If you have any questions or if you found any problems with this repository, ple
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/IQAIcom/adk-ts-samples.git
+   git clone https://github.com/IQOfficial/adk-ts-samples.git
    cd adk-ts-samples
    ```
 
@@ -100,9 +100,9 @@ Please check out our [Contributing Guide](CONTRIBUTION.md) for detailed informat
 
 Join our community to discuss ideas, ask questions, and share your projects:
 
-- [GitHub Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [GitHub Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ## 📜 License
 

--- a/apps/atp-micropayment-agent/README.md
+++ b/apps/atp-micropayment-agent/README.md
@@ -124,7 +124,7 @@ graph TB
 1. Clone this repository
 
 ```bash
-git clone https://github.com/IQAIcom/adk-ts-samples.git
+git clone https://github.com/IQOfficial/adk-ts-samples.git
 cd adk-ts-samples/agents/atp-micropayment-agent
 ```
 
@@ -283,8 +283,8 @@ Expected response showing endpoint prices:
 
 - [ADK-TS Documentation](https://adk.iqai.com/)
 - [ADK-TS CLI Documentation](https://adk.iqai.com/docs/cli)
-- [ADK-TS Samples Repository](https://github.com/IQAIcom/adk-ts-samples)
-- [ADK-TS GitHub Repository](https://github.com/IQAIcom/adk-ts)
+- [ADK-TS Samples Repository](https://github.com/IQOfficial/adk-ts-samples)
+- [ADK-TS GitHub Repository](https://github.com/IQOfficial/adk-ts)
 
 ### x402 Protocol
 
@@ -299,13 +299,13 @@ Expected response showing endpoint prices:
 
 ### Community
 
-- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ## Contributing
 
-This ATP Micropayment Agent is part of the [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples) repository, a collection of sample projects demonstrating ADK-TS capabilities.
+This ATP Micropayment Agent is part of the [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples) repository, a collection of sample projects demonstrating ADK-TS capabilities.
 
 We welcome contributions to the ADK-TS Samples repository! You can:
 

--- a/apps/atp-micropayment-agent/package.json
+++ b/apps/atp-micropayment-agent/package.json
@@ -36,7 +36,7 @@
 		"typescript": "^5.9.2"
 	},
 	"keywords": [],
-	"author": "IQAICOM",
+	"author": "IQOfficial",
 	"license": "MIT",
 	"packageManager": "pnpm@10.13.1"
 }

--- a/apps/crypto-tax-agent/README.md
+++ b/apps/crypto-tax-agent/README.md
@@ -110,7 +110,7 @@ graph TB
 1. Clone this repository
 
 ```bash
-git clone https://github.com/IQAIcom/adk-ts-samples.git
+git clone https://github.com/IQOfficial/adk-ts-samples.git
 cd adk-ts-samples/apps/crypto-tax-agent
 ```
 
@@ -322,8 +322,8 @@ This is a **sample implementation** designed for educational purposes. Known lim
 
 - [ADK-TS Documentation](https://adk.iqai.com/)
 - [ADK-TS CLI Documentation](https://adk.iqai.com/docs/cli)
-- [ADK-TS Samples Repository](https://github.com/IQAIcom/adk-ts-samples)
-- [ADK-TS GitHub Repository](https://github.com/IQAICOM/adk-ts)
+- [ADK-TS Samples Repository](https://github.com/IQOfficial/adk-ts-samples)
+- [ADK-TS GitHub Repository](https://github.com/IQOfficial/adk-ts)
 
 ### APIs & Services
 
@@ -338,13 +338,13 @@ This is a **sample implementation** designed for educational purposes. Known lim
 
 ### Community
 
-- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ## Contributing
 
-This Crypto Tax Agent is part of the [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples) repository, a collection of sample projects demonstrating ADK-TS capabilities.
+This Crypto Tax Agent is part of the [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples) repository, a collection of sample projects demonstrating ADK-TS capabilities.
 
 We welcome contributions to the ADK-TS Samples repository! You can:
 

--- a/apps/customer-support-agent/README.md
+++ b/apps/customer-support-agent/README.md
@@ -91,7 +91,7 @@ vite.config.ts                     # Vite config with /chat proxy to localhost:3
 1. Clone this repository
 
 ```bash
-git clone https://github.com/IQAIcom/adk-ts-samples.git
+git clone https://github.com/IQOfficial/adk-ts-samples.git
 cd adk-ts-samples/apps/customer-support-agent
 ```
 
@@ -196,8 +196,8 @@ Replace the knowledge-base with IT runbooks and FAQs, and the HTTP tool with Ser
 - [ADK-TS Documentation](https://adk.iqai.com/)
 - [ADK-TS CLI Documentation](https://adk.iqai.com/docs/cli)
 - [Built-in Tools Reference](https://adk.iqai.com/docs/framework/tools/built-in-tools)
-- [ADK-TS Samples Repository](https://github.com/IQAIcom/adk-ts-samples)
-- [ADK-TS GitHub Repository](https://github.com/IQAICOM/adk-ts)
+- [ADK-TS Samples Repository](https://github.com/IQOfficial/adk-ts-samples)
+- [ADK-TS GitHub Repository](https://github.com/IQOfficial/adk-ts)
 
 ### APIs & Services
 
@@ -207,13 +207,13 @@ Replace the knowledge-base with IT runbooks and FAQs, and the HTTP tool with Ser
 
 ### Community
 
-- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ## Contributing
 
-This Customer Support Agent is part of the [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples) repository, a collection of example projects demonstrating ADK-TS capabilities.
+This Customer Support Agent is part of the [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples) repository, a collection of example projects demonstrating ADK-TS capabilities.
 
 We welcome contributions to the ADK-TS Samples repository! You can:
 

--- a/apps/dao-proposal-analyzer/README.md
+++ b/apps/dao-proposal-analyzer/README.md
@@ -75,7 +75,7 @@ graph TB
 1. Clone this repository
 
 ```bash
-git clone https://github.com/IQAIcom/adk-ts-samples.git
+git clone https://github.com/IQOfficial/adk-ts-samples.git
 cd adk-ts-samples/apps/dao-proposal-analyzer
 ```
 
@@ -174,8 +174,8 @@ You can also **add agents** — insert a historical comparison agent that benchm
 
 - [ADK-TS Documentation](https://adk.iqai.com/)
 - [ADK-TS CLI Documentation](https://adk.iqai.com/docs/cli)
-- [ADK-TS Samples Repository](https://github.com/IQAIcom/adk-ts-samples)
-- [ADK-TS GitHub Repository](https://github.com/IQAICOM/adk-ts)
+- [ADK-TS Samples Repository](https://github.com/IQOfficial/adk-ts-samples)
+- [ADK-TS GitHub Repository](https://github.com/IQOfficial/adk-ts)
 
 ### DAO Governance
 
@@ -192,13 +192,13 @@ You can also **add agents** — insert a historical comparison agent that benchm
 
 ### Community
 
-- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ## Contributing
 
-This DAO Proposal Analyzer is part of the [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples) repository.
+This DAO Proposal Analyzer is part of the [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples) repository.
 
 We welcome contributions to the ADK-TS Samples repository! You can:
 

--- a/apps/debank-portfolio-analyzer/README.md
+++ b/apps/debank-portfolio-analyzer/README.md
@@ -91,7 +91,7 @@ graph LR
 1. **Clone and enter the app**
 
    ```bash
-   git clone https://github.com/IQAIcom/adk-ts-samples.git
+   git clone https://github.com/IQOfficial/adk-ts-samples.git
    cd adk-ts-samples/apps/debank-portfolio-analyzer
    ```
 
@@ -221,20 +221,20 @@ To **reuse debank-mcp in your own agent**: copy the `tools.ts` pattern, ensure `
 
 - [ADK-TS Documentation](https://adk.iqai.com/)
 - [ADK-TS CLI](https://adk.iqai.com/docs/cli)
-- [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples)
-- [ADK-TS GitHub](https://github.com/IQAIcom/adk-ts)
+- [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples)
+- [ADK-TS GitHub](https://github.com/IQOfficial/adk-ts)
 
 ### Community
 
-- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ---
 
 ## Contributing
 
-This sample is part of [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples). Contributions that improve debank-mcp adoption or this reference integration are welcome. See the [Contributing Guide](../../CONTRIBUTION.md) for guidelines.
+This sample is part of [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples). Contributions that improve debank-mcp adoption or this reference integration are welcome. See the [Contributing Guide](../../CONTRIBUTION.md) for guidelines.
 
 ## License
 

--- a/apps/debank-portfolio-analyzer/package.json
+++ b/apps/debank-portfolio-analyzer/package.json
@@ -13,7 +13,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/IQAIcom/adk-ts-samples.git"
+		"url": "git+https://github.com/IQOfficial/adk-ts-samples.git"
 	},
 	"keywords": [
 		"ai",
@@ -29,9 +29,9 @@
 	"author": "IQAI",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/IQAIcom/adk-ts-samples/issues"
+		"url": "https://github.com/IQOfficial/adk-ts-samples/issues"
 	},
-	"homepage": "https://github.com/IQAIcom/adk-ts-samples/tree/main/apps/debank-portfolio-analyzer#readme",
+	"homepage": "https://github.com/IQOfficial/adk-ts-samples/tree/main/apps/debank-portfolio-analyzer#readme",
 	"dependencies": {
 		"@iqai/adk": "0.6.2",
 		"dedent": "^1.7.0",

--- a/apps/research-assistant/README.md
+++ b/apps/research-assistant/README.md
@@ -95,7 +95,7 @@ src/
 1. Clone this repository
 
 ```bash
-git clone https://github.com/IQAIcom/adk-ts-samples.git
+git clone https://github.com/IQOfficial/adk-ts-samples.git
 cd adk-ts-samples/apps/research-assistant
 ```
 
@@ -212,8 +212,8 @@ recommender. Want to skip recommendations? Remove the recommender agent from the
 
 - [ADK-TS Documentation](https://adk.iqai.com/)
 - [ADK-TS CLI Documentation](https://adk.iqai.com/docs/cli)
-- [ADK-TS Samples Repository](https://github.com/IQAIcom/adk-ts-samples)
-- [ADK-TS GitHub Repository](https://github.com/IQAICOM/adk-ts)
+- [ADK-TS Samples Repository](https://github.com/IQOfficial/adk-ts-samples)
+- [ADK-TS GitHub Repository](https://github.com/IQOfficial/adk-ts)
 
 ### APIs & Services
 
@@ -223,13 +223,13 @@ recommender. Want to skip recommendations? Remove the recommender agent from the
 
 ### Community
 
-- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ## Contributing
 
-This Research Assistant is part of the [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples)
+This Research Assistant is part of the [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples)
 repository, a collection of example projects demonstrating ADK-TS capabilities.
 
 We welcome contributions to the ADK-TS Samples repository! You can:

--- a/apps/social-media-drafting-agent/README.md
+++ b/apps/social-media-drafting-agent/README.md
@@ -116,7 +116,7 @@ src/
 1. Clone this repository
 
 ```bash
-git clone https://github.com/IQAIcom/adk-ts-samples.git
+git clone https://github.com/IQOfficial/adk-ts-samples.git
 cd adk-ts-samples/apps/social-media-drafting-agent
 ```
 
@@ -235,8 +235,8 @@ to gather content from a source and produce it for several output surfaces:
 - [ADK-TS Documentation](https://adk.iqai.com/)
 - [Built-in Tools Reference](https://adk.iqai.com/docs/framework/tools/built-in-tools)
 - [Plugins Reference](https://adk.iqai.com/docs/framework/plugins)
-- [ADK-TS Samples Repository](https://github.com/IQAIcom/adk-ts-samples)
-- [ADK-TS GitHub Repository](https://github.com/IQAICOM/adk-ts)
+- [ADK-TS Samples Repository](https://github.com/IQOfficial/adk-ts-samples)
+- [ADK-TS GitHub Repository](https://github.com/IQOfficial/adk-ts)
 
 ### Next.js
 
@@ -250,13 +250,13 @@ to gather content from a source and produce it for several output surfaces:
 
 ### Community
 
-- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ## Contributing
 
-The Draft Desk is part of the [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples)
+The Draft Desk is part of the [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples)
 repository, a collection of example projects demonstrating ADK-TS capabilities.
 
 We welcome contributions to the ADK-TS Samples repository! You can:

--- a/apps/telegram-personal-assistant/README.md
+++ b/apps/telegram-personal-assistant/README.md
@@ -131,7 +131,7 @@ graph TB
 1. Clone this repository
 
 ```bash
-git clone https://github.com/IQAIcom/adk-ts-samples.git
+git clone https://github.com/IQOfficial/adk-ts-samples.git
 cd adk-ts-samples/apps/telegram-personal-assistant
 ```
 
@@ -307,8 +307,8 @@ You can also **add integrations** — connect Google Calendar for syncing remind
 
 - [ADK-TS Documentation](https://adk.iqai.com/)
 - [ADK-TS CLI Documentation](https://adk.iqai.com/docs/cli)
-- [ADK-TS Samples Repository](https://github.com/IQAIcom/adk-ts-samples)
-- [ADK-TS GitHub Repository](https://github.com/IQAICOM/adk-ts)
+- [ADK-TS Samples Repository](https://github.com/IQOfficial/adk-ts-samples)
+- [ADK-TS GitHub Repository](https://github.com/IQOfficial/adk-ts)
 
 ### APIs & Services
 
@@ -319,13 +319,13 @@ You can also **add integrations** — connect Google Calendar for syncing remind
 
 ### Community
 
-- [ADK-TS Discussions](https://github.com/IQAIcom/adk-ts/discussions)
+- [ADK-TS Discussions](https://github.com/IQOfficial/adk-ts/discussions)
 - [ADK-TS Builders Community](https://t.me/+Z37x8uf6DLE3ZTQ8)
-- [IQ AI Community](https://t.me/IQAICOM)
+- [IQ AI Community](https://t.me/IQOfficial)
 
 ## Contributing
 
-This Telegram Personal Assistant is part of the [ADK-TS Samples](https://github.com/IQAIcom/adk-ts-samples) repository, a collection of sample projects demonstrating ADK-TS capabilities.
+This Telegram Personal Assistant is part of the [ADK-TS Samples](https://github.com/IQOfficial/adk-ts-samples) repository, a collection of sample projects demonstrating ADK-TS capabilities.
 
 We welcome contributions to the ADK-TS Samples repository! You can:
 

--- a/apps/telegram-personal-assistant/package.json
+++ b/apps/telegram-personal-assistant/package.json
@@ -29,6 +29,6 @@
 		"typescript": "^5.9.3"
 	},
 	"keywords": [],
-	"author": "IQAICOM",
+	"author": "IQOfficial",
 	"license": "MIT"
 }

--- a/packages/adk/package.json
+++ b/packages/adk/package.json
@@ -12,7 +12,7 @@
 		"adk",
 		"typescript"
 	],
-	"author": "IQAICOM",
+	"author": "IQOfficial",
 	"license": "MIT",
 	"peerDependencies": {
 		"@iqai/adk": "^0.5.6"


### PR DESCRIPTION
Renames `IQAICOM`, `IQAIcom`, and `iqaicom` references to `IQOfficial` / `iqofficial` (case-preserving) as part of the brand handle rename. Covers Twitter/X handles, GitHub URLs, Telegram links, package metadata, badges, and docs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>